### PR TITLE
Send the notification email after a payment

### DIFF
--- a/wp-express-checkout/includes/class-wpec-process-ipn.php
+++ b/wp-express-checkout/includes/class-wpec-process-ipn.php
@@ -44,6 +44,9 @@ class WPEC_Process_IPN {
 	 * Processes the payment on AJAX call.
 	 */
 	public function wpec_process_payment() {
+
+		// TODO: AJAX Nonce verification.
+
 		if ( ! isset( $_POST['wp_ppdg_payment'] ) ) {
 			// no payment data provided.
 			_e( 'No payment data received.', 'paypal-express-checkout' );
@@ -98,7 +101,7 @@ class WPEC_Process_IPN {
 		// let's insert order.
 		$order = OrdersWPEC::get_instance();
 
-		$order->insert(
+		$order_id = $order->insert(
 			array(
 				'item_name'   => $item_name,
 				'price'       => $price,
@@ -112,7 +115,66 @@ class WPEC_Process_IPN {
 			$payment['payer']
 		);
 
-		// TODO - Send email notifications.
+		$wpec_plugin = WPEC_Main::get_instance();
+
+		$product_details = $item_name . ' x ' . $quantity . ' - ' . number_format( $amount, 2, '.', '' ) . ' ' . $currency . "\n";
+		/* translators:  %s - download link */
+		$product_details .= sprintf( __( 'Download Link: %s', 'paypal-express-checkout' ), base64_decode( $url ) ) . "\n";
+
+		$address = '';
+		if ( ! empty( $payment['purchase_units'][0]['shipping']['address'] ) ) {
+			$address = implode( ', ', (array) $payment['purchase_units'][0]['shipping']['address'] );
+		}
+
+		$args = array(
+			'first_name'      => $payment['payer']['name']['given_name'],
+			'last_name'       => $payment['payer']['name']['surname'],
+			'product_details' => $product_details,
+			'payer_email'     => $payment['payer']['email_address'],
+			'transaction_id'  => $payment['id'],
+			'purchase_amt'    => $amount,
+			'purchase_date'   => date( 'Y-m-d' ),
+			'coupon_code'     => '', // Seems like not implemented yet.
+			'address'         => $address,
+			'order_id'        => $order_id,
+		);
+
+		// Send email to buyer if needs.
+		if ( $wpec_plugin->get_setting( 'send_buyer_email' ) && ! empty( $payment['payer']['email_address'] ) ) {
+
+			$buyer_email = $payment['payer']['email_address'];
+			$from_email  = $wpec_plugin->get_setting( 'buyer_from_email' );
+			$subject     = $wpec_plugin->get_setting( 'buyer_email_subj' );
+			$subject     = $this->apply_dynamic_tags( $subject, $args );
+			$body        = $wpec_plugin->get_setting( 'buyer_email_body' );
+
+			$args['email_body'] = $body;
+
+			$body = $this->apply_dynamic_tags( $body, $args );
+			$body = apply_filters( 'wpec_buyer_notification_email_body', $body, $payment, $args );
+
+			$headers = 'From: ' . $from_email . "\r\n";
+
+			wp_mail( $buyer_email, $subject, $body, $headers );
+
+			update_post_meta( $order_id, 'wpsc_buyer_email_sent', 'Email sent to: ' . $buyer_email );
+		}
+
+		// Send email to seller if needs.
+		if ( $wpec_plugin->get_setting( 'send_seller_email' ) && ! empty( $wpec_plugin->get_setting( 'notify_email_address' ) ) ) {
+
+			$notify_email = $wpec_plugin->get_setting( 'notify_email_address' );
+
+			$seller_email_subject = $wpec_plugin->get_setting( 'seller_email_subj' );
+			$seller_email_subject = $this->apply_dynamic_tags( $seller_email_subject, $args );
+
+			$seller_email_body = $wpec_plugin->get_setting( 'seller_email_body' );
+			$seller_email_body = $this->apply_dynamic_tags( $seller_email_body, $args );
+			$seller_email_body = apply_filters( 'wpec_seller_notification_email_body', $seller_email_body, $payment, $args );
+
+			wp_mail( $notify_email, $seller_email_subject, $seller_email_body, $headers );
+		}
+
 		// Trigger the action hook.
 		do_action( 'wpec_payment_completed', $payment );
 
@@ -131,6 +193,42 @@ class WPEC_Process_IPN {
 		echo wp_json_encode( $res );
 
 		exit;
+	}
+
+	/**
+	 * Replaces tags in the text with appropriate values.
+	 *
+	 * @param string $text The text with tags to be replaced.
+	 * @param array  $args The array of the tags values.
+	 *
+	 * @return string
+	 */
+	private function apply_dynamic_tags( $text, $args ) {
+
+		$white_list = array(
+			'first_name',
+			'last_name',
+			'product_details',
+			'payer_email',
+			'transaction_id',
+			'purchase_amt',
+			'purchase_date',
+			'coupon_code',
+			'address',
+			'order_id',
+		);
+
+		$tags = array();
+		$vals = array();
+
+		foreach ( $white_list as $item ) {
+			$tags[] = "{{$item}}";
+			$vals[] = ( isset( $args[ $item ] ) ) ? $args[ $item ] : '';
+		}
+
+		$body = stripslashes( str_replace( $tags, $vals, $text ) );
+
+		return $body;
 	}
 
 }

--- a/wp-express-checkout/includes/class-wpec-process-ipn.php
+++ b/wp-express-checkout/includes/class-wpec-process-ipn.php
@@ -1,113 +1,136 @@
 <?php
-
-/* 
- * This class is used to prcoess the payment after successful charge.
- * 
+/**
+ * This class is used to process the payment after successful charge.
+ *
  * Inserts the payment date to the orders menu
  * Sends notification emails.
  * Triggers after payment processed hook: wpec_payment_completed
  * Sends to Thank You page.
  */
 
+/**
+ * Process IPN class
+ */
 class WPEC_Process_IPN {
 
-    protected static $instance = null;
+	/**
+	 * The class instance.
+	 *
+	 * @var WPEC_Process_IPN
+	 */
+	protected static $instance = null;
 
-    function __construct() {
-        add_action('wp_ajax_wpec_process_payment', array($this, 'wpec_process_payment'));
-        add_action('wp_ajax_nopriv_wpec_process_payment', array($this, 'wpec_process_payment'));
-    }
+	/**
+	 * Construct the instance.
+	 */
+	public function __construct() {
+		add_action( 'wp_ajax_wpec_process_payment', array( $this, 'wpec_process_payment' ) );
+		add_action( 'wp_ajax_nopriv_wpec_process_payment', array( $this, 'wpec_process_payment' ) );
+	}
 
-    public static function get_instance() {
-        if (null == self::$instance) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
+	/**
+	 * Retrieves the instance.
+	 *
+	 * @return WPEC_Process_IPN
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
 
-    function wpec_process_payment() {
-        if (!isset($_POST['wp_ppdg_payment'])) {
-            //no payment data provided
-            _e('No payment data received.', 'paypal-express-checkout');
-            exit;
-        }
-        $payment = $_POST['wp_ppdg_payment'];
+	/**
+	 * Processes the payment on AJAX call.
+	 */
+	public function wpec_process_payment() {
+		if ( ! isset( $_POST['wp_ppdg_payment'] ) ) {
+			// no payment data provided.
+			_e( 'No payment data received.', 'paypal-express-checkout' );
+			exit;
+		}
 
-        if (strtoupper($payment['status']) !== 'COMPLETED') {
-            //payment is unsuccessful
-            printf(__('Payment is not approved. Status: %s', 'paypal-express-checkout'), $payment['status']);
-            exit;
-        }
+		$payment = $_POST['wp_ppdg_payment'];
 
-        // get item name
-        $item_name = $payment['purchase_units'][0]['description'];
-        // let's check if the payment matches transient data
-        $trans_name = 'wp-ppdg-' . sanitize_title_with_dashes($item_name);
-        $trans = get_transient($trans_name);
-        if (!$trans) {
-            //no price set
-            _e('No transaction info found in transient.', 'paypal-express-checkout');
-            exit;
-        }
-        $price = $trans['price'];
-        $quantity = $trans['quantity'];
-        $currency = $trans['currency'];
-        $url = $trans['url'];
+		if ( strtoupper( $payment['status'] ) !== 'COMPLETED' ) {
+			// payment is unsuccessful.
+			printf( __( 'Payment is not approved. Status: %s', 'paypal-express-checkout' ), $payment['status'] );
+			exit;
+		}
 
-        if ($trans['custom_quantity']) {
-            //custom quantity enabled. let's take quantity from PayPal results
-            $quantity = $payment['purchase_units'][0]['items'][0]['quantity'];
-        }
+		// get item name.
+		$item_name = $payment['purchase_units'][0]['description'];
+		// let's check if the payment matches transient data.
+		$trans_name = 'wp-ppdg-' . sanitize_title_with_dashes( $item_name );
+		$trans      = get_transient( $trans_name );
+		if ( ! $trans ) {
+			// no price set.
+			_e( 'No transaction info found in transient.', 'paypal-express-checkout' );
+			exit;
+		}
+		$price    = $trans['price'];
+		$quantity = $trans['quantity'];
+		$currency = $trans['currency'];
+		$url      = $trans['url'];
 
-        $amount = $payment['purchase_units'][0]['amount']['value'];
+		if ( $trans['custom_quantity'] ) {
+			// custom quantity enabled. let's take quantity from PayPal results.
+			$quantity = $payment['purchase_units'][0]['items'][0]['quantity'];
+		}
 
-        //check if amount paid matches price x quantity
-        if ($amount != $price * $quantity) {
-            //payment amount mismatch
-            _e('Payment amount mismatch original price.', 'paypal-express-checkout');
-            exit;
-        }
+		$amount = $payment['purchase_units'][0]['amount']['value'];
 
-        //check if payment currency matches
-        if ($payment['purchase_units'][0]['amount']['currency_code'] !== $currency) {
-            //payment currency mismatch
-            _e('Payment currency mismatch.', 'paypal-express-checkout');
-            exit;
-        }
+		// check if amount paid matches price x quantity.
+		if ( $amount != $price * $quantity ) {
+			// payment amount mismatch.
+			_e( 'Payment amount mismatch original price.', 'paypal-express-checkout' );
+			exit;
+		}
 
-        //If code execution got this far, it means everything is ok with payment
-        //let's insert order
-        $order = OrdersWPEC::get_instance();
+		// check if payment currency matches.
+		if ( $payment['purchase_units'][0]['amount']['currency_code'] !== $currency ) {
+			// payment currency mismatch.
+			_e( 'Payment currency mismatch.', 'paypal-express-checkout' );
+			exit;
+		}
 
-        $order->insert(array(
-            'item_name' => $item_name,
-            'price' => $price,
-            'quantity' => $quantity,
-            'amount' => $amount,
-            'currency' => $currency,
-            'state' => $payment['status'],
-            'id' => $payment['id'],
-            'create_time' => $payment['create_time'],
-        ), $payment['payer']);
+		// If code execution got this far, it means everything is ok with payment
+		// let's insert order.
+		$order = OrdersWPEC::get_instance();
 
-        //TODO - Send email notifications.
-        
-        //Trigger the action hook
-        do_action('wpec_payment_completed', $payment);
+		$order->insert(
+			array(
+				'item_name'   => $item_name,
+				'price'       => $price,
+				'quantity'    => $quantity,
+				'amount'      => $amount,
+				'currency'    => $currency,
+				'state'       => $payment['status'],
+				'id'          => $payment['id'],
+				'create_time' => $payment['create_time'],
+			),
+			$payment['payer']
+		);
 
-        //Thank you message
-        $res = array();
-        $res['title'] = __('Payment Completed', 'paypal-express-checkout');
+		// TODO - Send email notifications.
+		// Trigger the action hook.
+		do_action( 'wpec_payment_completed', $payment );
 
-        $thank_you_msg = '<div class="wp_ppdg_thank_you_message"><p>' . __('Thank you for your purchase.', 'paypal-express-checkout') . '</p>';
-        $click_here_str = sprintf(__('Please <a href="%s">click here</a> to download the file.', 'paypal-express-checkout'), base64_decode($url));
-        $thank_you_msg .= '<br /><p>' . $click_here_str . '</p></div>';
-        $thank_you_msg = apply_filters('wp_ppdg_thank_you_message', $thank_you_msg);
-        $res['msg'] = $thank_you_msg;
+		// Thank you message.
+		$res = array(
+			'title' => __( 'Payment Completed', 'paypal-express-checkout' ),
+		);
 
-        echo json_encode($res);
+		$thank_you_msg  = '<div class="wp_ppdg_thank_you_message"><p>' . __( 'Thank you for your purchase.', 'paypal-express-checkout' ) . '</p>';
+		$click_here_str = sprintf( __( 'Please <a href="%s">click here</a> to download the file.', 'paypal-express-checkout' ), base64_decode( $url ) );
+		$thank_you_msg .= '<br /><p>' . $click_here_str . '</p></div>';
+		$thank_you_msg  = apply_filters( 'wp_ppdg_thank_you_message', $thank_you_msg );
 
-        exit;
-    }
+		$res['msg'] = $thank_you_msg;
+
+		echo wp_json_encode( $res );
+
+		exit;
+	}
 
 }


### PR DESCRIPTION
First commit formats the code according WP Standards
Second commit implements the notifications.

Note: reviewing code is better starting from the second commit to avoid formatting noise.
Note2: dynamic tags replacement ignores tag `{coupon_code}` since it's not implemented yet. Don't know if it will be.