### PR TITLE
Templates

### DIFF
--- a/wp-express-checkout/admin/includes/class-products.php
+++ b/wp-express-checkout/admin/includes/class-products.php
@@ -40,10 +40,10 @@ class PPECProducts {
 	    'not_found'		 => __( 'Not found', 'wp-express-checkout' ),
 	    'not_found_in_trash'	 => __( 'Not found in Trash', 'wp-express-checkout' ),
 	);
-        
+
         //Using custom dashicon font icon.
 	$menu_icon	 = 'dashicons-wpec-dashicon-1'; //WPEC_PLUGIN_URL . '/admin/assets/img/wpec-dashicon.png';
-        
+
 	$slug		 = untrailingslashit( self::$products_slug );
 	$args		 = array(
 	    'labels'		 => $labels,
@@ -55,7 +55,7 @@ class PPECProducts {
 	    'has_archive'		 => false,
 	    'hierarchical'		 => false,
 	    'rewrite'		 => array( 'slug' => $slug ),
-	    'supports'		 => array( 'title' ),
+	    'supports'		 => array( 'title', 'thumbnail' ),
 	    'show_ui'		 => true,
 	    'show_in_nav_menus'	 => true,
 	    'show_in_admin_bar'	 => true,

--- a/wp-express-checkout/includes/class-wpec-utility-functions.php
+++ b/wp-express-checkout/includes/class-wpec-utility-functions.php
@@ -6,35 +6,61 @@ class WPEC_Utility_Functions {
 
 	}
 
+	/**
+	 * Returns the price given the arguments in settings
+	 *
+	 * @param  int    $price             The numerical value to format.
+	 * @param  string $override_currency The currency the value is in.
+	 * @return string                    The formatted price.
+	 */
+	public static function price_format( $price, $override_currency = '' ) {
+		$ppdg = WPEC_Main::get_instance();
+
+		$formatted_price = number_format( $price, 2, '.', '' );
+		$currency_code   = ( empty( $override_currency ) ) ? $ppdg->get_setting( 'currency_code' ) : $override_currency;
+		$position        = 'right_space'; // Expected to be a setting.
+
+		$formats = array(
+			'left'        => '{symbol}{price}',
+			'left_space'  => '{symbol} {price}',
+			'right'       => '{price}{symbol}',
+			'right_space' => '{price} {symbol}',
+		);
+
+		$search  = array( '{price}', '{symbol}' );
+		$replace = array( $formatted_price, $currency_code );
+
+		return str_replace( $search, $replace, $formats[ $position ] );
+	}
+
 	/*
 	 * Replaced the dynamic tags with order details (given the order_id)
 	 */
-
 	public static function replace_dynamic_order_tags( $text, $order_id ) {
 		$payment_details = get_post_meta( $order_id, 'ppec_payment_details', true );
-		$payer_details = get_post_meta( $order_id, 'ppec_payer_details', true );
+		$payer_details   = get_post_meta( $order_id, 'ppec_payer_details', true );
 
 		$formatted_amount = number_format( $payment_details['amount'], 2, '.', '' );
-		$product_details = $payment_details['item_name'] . ' x ' . $payment_details['quantity'] . ' - ' . $formatted_amount . ' ' . $payment_details['currency'] . "\n";
+		$product_details  = $payment_details['item_name'] . ' x ' . $payment_details['quantity'] . ' - ' . self::price_format( $payment_details['amount'], $payment_details['currency'] ) . "\n";
 
 		$tags_vals = array(
-			'first_name' => $payer_details['name']['given_name'],
-			'last_name' => $payer_details['name']['surname'],
+			'first_name'      => $payer_details['name']['given_name'],
+			'last_name'       => $payer_details['name']['surname'],
 			'product_details' => $product_details,
-			'payer_email' => $payer_details['email_address'],
-			'transaction_id' => $payment_details['id'],
-			'purchase_amt' => $formatted_amount,
-			'purchase_date' => date( 'Y-m-d' ),
-			'coupon_code' => '', // Seems like not implemented yet.
-			'address' => '', // Not implemented yet.
-			'order_id' => $order_id,
+			'payer_email'     => $payer_details['email_address'],
+			'transaction_id'  => $payment_details['id'],
+			'purchase_amt'    => $formatted_amount,
+			'purchase_date'   => date( 'Y-m-d' ),
+			'coupon_code'     => '', // Seems like not implemented yet.
+			'address'         => '', // Not implemented yet.
+			'order_id'        => $order_id,
 		);
 
 		$tags = array();
 		$vals = array();
 		foreach ( $tags_vals as $key => $value ) {
 			$tags[] = "{{$key}}";
-			$vals[] = ( isset( $tags_vals[$key] ) ) ? $tags_vals[$key] : '';
+			$vals[] = ( isset( $tags_vals[ $key ] ) ) ? $tags_vals[ $key ] : '';
 		}
 
 		$text = stripslashes( str_replace( $tags, $vals, $text ) );

--- a/wp-express-checkout/public/assets/css/public.css
+++ b/wp-express-checkout/public/assets/css/public.css
@@ -1,5 +1,47 @@
 /* This stylesheet is used to style the public-facing components of the plugin. */
 
+.wpec-product-item {
+    display: block;
+    border: 1px solid #E7E9EB;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.05);
+    margin-top: 10px;
+    margin-bottom: 10px;
+    padding: 15px;
+}
+.wpec-product-item-thumbnail img {
+    width: 75px;
+    height: 75px;
+    float: left;
+    margin-right: 10px;
+}
+
+.wpec-product-name {
+    float: left;
+}
+
+.wpec-product-name .wpec-entry-title {
+    font-size: 24px;
+    font-weight: bold;
+    line-height: 75px;
+	margin: 0;
+}
+
+.wpec-product-description {
+    margin: 15px 0 15px 0;
+    border-bottom: 1px solid #EEEEEE;
+}
+
+.wpec-price-container {
+    font-weight: bold;
+    margin: 5px 0px;
+}
+
+@media (max-width: 500px) {
+    .wpec-price-container {
+		text-align: center;
+    }
+}
+
 .wpec-error-message{
 	color: red;
 	font-weight: bold;

--- a/wp-express-checkout/public/views/templates/content-product-1.php
+++ b/wp-express-checkout/public/views/templates/content-product-1.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * The product item template
+ *
+ * @package wp-express-checkout
+ */
+
+$wpec_shortcode = WPECShortcode::get_instance();
+?>
+
+<div class="wpec-title-container">
+	<?php the_title( sprintf( '<h3 class="wpec-entry-title"><a href="%1$s" title="%2$s" rel="bookmark">', esc_url( get_permalink() ), esc_attr( get_the_title() ) ), '</a></h3>' ); ?>
+</div>
+
+
+<div class="wpec-thumbnail-container">
+	<?php the_post_thumbnail( 'thumbnail' ); ?>
+</div>
+
+<div class="wpec-content-container">
+	<?php the_excerpt(); ?>
+</div>
+
+<div class="wpec-price-container">
+	<span class="wpec-price">
+		<?php echo WPEC_Utility_Functions::price_format( $wpec_button_args['price'] ) ?>
+	</span>
+</div>
+<?php
+
+echo $wpec_shortcode->generate_pp_express_checkout_button( $wpec_button_args );

--- a/wp-express-checkout/public/views/templates/content-product-1.php
+++ b/wp-express-checkout/public/views/templates/content-product-1.php
@@ -8,24 +8,24 @@
 $wpec_shortcode = WPECShortcode::get_instance();
 ?>
 
-<div class="wpec-title-container">
-	<?php the_title( sprintf( '<h3 class="wpec-entry-title"><a href="%1$s" title="%2$s" rel="bookmark">', esc_url( get_permalink() ), esc_attr( get_the_title() ) ), '</a></h3>' ); ?>
+<div class="wpec-product-item">
+	<div class="wpec-product-item-top">
+		<div class="wpec-product-item-thumbnail">
+			<?php the_post_thumbnail( 'thumbnail' ); ?>
+		</div>
+		<div class="wpec-product-name">
+			<?php the_title( sprintf( '<h3 class="wpec-entry-title"><a href="%1$s" title="%2$s" rel="bookmark">', esc_url( get_permalink() ), esc_attr( get_the_title() ) ), '</a></h3>' ); ?>
+		</div>
+	</div>
+	<div style="clear:both;"></div>
+	<div class="wpec-product-description">
+		<?php the_excerpt(); ?>
+	</div>
+	<div class="wpec-price-container">
+		<span class="wpec-price-amount"><?php echo WPEC_Utility_Functions::price_format( $wpec_button_args['price'] ) ?></span> <span class="wpec-new-price-amount"></span> <!--<span class="wpec-quantity"></span>-->
+		<!--<div class="wpec_under_price_line"></div>-->
+	</div>
+	<div class="wpec-product-buy-button">
+		<?php echo $wpec_shortcode->generate_pp_express_checkout_button( $wpec_button_args ); ?>
+	</div>
 </div>
-
-
-<div class="wpec-thumbnail-container">
-	<?php the_post_thumbnail( 'thumbnail' ); ?>
-</div>
-
-<div class="wpec-content-container">
-	<?php the_excerpt(); ?>
-</div>
-
-<div class="wpec-price-container">
-	<span class="wpec-price">
-		<?php echo WPEC_Utility_Functions::price_format( $wpec_button_args['price'] ) ?>
-	</span>
-</div>
-<?php
-
-echo $wpec_shortcode->generate_pp_express_checkout_button( $wpec_button_args );

--- a/wp-express-checkout/public/views/templates/content-product-2.php
+++ b/wp-express-checkout/public/views/templates/content-product-2.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Single product template
+ *
+ * @package wp-express-checkout
+ */
+
+$wpec_shortcode = WPECShortcode::get_instance();
+?>
+
+<div class="wpec_price_container">
+	<span class="wpec_price_container">
+		<?php echo WPEC_Utility_Functions::price_format( $wpec_button_args['price'] ) ?>
+	</span>
+</div>
+<?php
+
+echo $wpec_shortcode->generate_pp_express_checkout_button( $wpec_button_args );

--- a/wp-express-checkout/public/views/templates/content-product-2.php
+++ b/wp-express-checkout/public/views/templates/content-product-2.php
@@ -8,11 +8,12 @@
 $wpec_shortcode = WPECShortcode::get_instance();
 ?>
 
-<div class="wpec_price_container">
-	<span class="wpec_price_container">
-		<?php echo WPEC_Utility_Functions::price_format( $wpec_button_args['price'] ) ?>
-	</span>
+<div class="wpec-product-item">
+	<div class="wpec-price-container">
+		<span class="wpec-price-amount"><?php echo WPEC_Utility_Functions::price_format( $wpec_button_args['price'] ) ?></span> <span class="wpec-new-price-amount"></span> <!--<span class="wpec-quantity"></span>-->
+		<!--<div class="wpec_under_price_line"></div>-->
+	</div>
+	<div class="wpec-product-buy-button">
+		<?php echo $wpec_shortcode->generate_pp_express_checkout_button( $wpec_button_args ); ?>
+	</div>
 </div>
-<?php
-
-echo $wpec_shortcode->generate_pp_express_checkout_button( $wpec_button_args );


### PR DESCRIPTION
Plugin now uses templates for displaying the products.

User can specify template number as the shortcode parameter:
`[wp_express_checkout product_id="4" template="1"]`

Currently, available only two templates:
 * `content-product-1.php` - to render the product item with full details.
 * `content-product-2.php` - to render the product details on the single product page.

If user didn't specify the `template` parameter, only button will be shown.

**Template look up priority:**
1. Child theme: `yourtheme/wpec/content-product-{$template}.php`
2. Parent theme: `yourtheme/wpec/content-product-{$template}.php`
3. Plugin: `wp-express-checkout/public/views/templates/content-product-{$template}.php`
4. If still no found - render only the button.

Markup and styles taken from the Stripe plugin:
![image](https://user-images.githubusercontent.com/4242025/72522178-de031480-387e-11ea-98c7-0fadfbed07a0.png)

