### PR TITLE
Thank you page customizations

### DIFF
--- a/wp-express-checkout/includes/class-utils.php
+++ b/wp-express-checkout/includes/class-utils.php
@@ -134,6 +134,7 @@ class Utils {
 			'transaction_id'  => $order->get_resource_id(),
 			'purchase_amt'    => $order->get_total(),
 			'purchase_date'   => date( 'Y-m-d' ),
+			'currency_code'   => $order->get_currency(),
 			'coupon_code'     => ! empty( $coupon_item['mata']['code'] ) ? $coupon_item['mata']['code'] : 0,
 			'address'         => '', // Not implemented yet.
 			'order_id'        => $order_id,
@@ -166,6 +167,7 @@ class Utils {
 			'purchase_amt',
 			'purchase_date',
 			'coupon_code',
+			'currency_code',
 			'address',
 			'order_id',
 		);

--- a/wp-express-checkout/public/includes/class-shortcodes.php
+++ b/wp-express-checkout/public/includes/class-shortcodes.php
@@ -315,9 +315,12 @@ class Shortcodes {
 	/**
 	 * Thank You page shortcode.
 	 *
+	 * @param array  $atts    An array of attributes. There are no attributes for now.
+	 * @param string $content The shortcode content or null if not set.
+	 *
 	 * @return string
 	 */
-	public function shortcode_wpec_thank_you() {
+	public function shortcode_wpec_thank_you( $atts = array(), $content = '' ) {
 
 		$error_message = '';
 
@@ -347,43 +350,27 @@ class Shortcodes {
 			return $this->show_err_msg( sprintf( __( 'Payment is not approved. Status: %s', 'wp-express-checkout' ), $order->get_data( 'state' ) ), 'order-state' );
 		}
 
-		$thank_you_msg  = '';
-		$thank_you_msg .= '<div class="wpec_thank_you_message">';
-		$thank_you_msg .= '<p>' . __( 'Thank you for your purchase.', 'wp-express-checkout' ) . '</p>';
+		if ( empty( $content ) ) {
+			$located = self::locate_template( 'content-thank-you.php' );
 
-		$thank_you_msg .= '<p>' . __( 'Your purchase details are below:', 'wp-express-checkout' ) . '</p>';
-		$thank_you_msg .= '<p>{product_details}</p>';
-		$thank_you_msg .= '<p>' . __( 'Transaction ID: ', 'wp-express-checkout' ) . '{transaction_id}</p>';
-
-		$downloads = View_Downloads::get_order_downloads_list( $order_id );
-
-		if ( ! empty( $downloads ) ) {
-			$download_var_str  = '';
-			$download_var_str .= "<br /><div class='wpec-thank-you-page-download-link'>";
-			$download_var_str .= '<span>' . _n( 'Download link', 'Download links', count( $downloads ), 'wp-express-checkout' ) . ':</span><br/>';
-			$download_txt      = __( 'Click here to download', 'wp-express-checkout' );
-			$link_tpl          = apply_filters( 'wpec_downloads_list_item_template', '%1$s - <a href="%2$s">%3$s</a><br/>' );
-			foreach ( $downloads as $name => $download_url ) {
-				$download_var_str .= sprintf( $link_tpl, $name, $download_url, $download_txt );
+			if ( $located ) {
+				ob_start();
+				require $located;
+				$content = ob_get_clean();
 			}
-			$download_var_str .= '</div>';
-
-			$thank_you_msg .= $download_var_str;
 		}
-
-		$thank_you_msg .= '</div>'; // end .wpec_thank_you_message.
 
 		$args = array(
 			'product_details' => self::generate_product_details_tag( $order ),
 		);
 
 		// Apply the dynamic tags.
-		$thank_you_msg = nl2br( Utils::replace_dynamic_order_tags( $thank_you_msg, $order_id, $args ) );
+		$content = Utils::replace_dynamic_order_tags( $content, $order_id, $args );
 
 		// Trigger the filter.
-		$thank_you_msg = apply_filters( 'wpec_thank_you_message', $thank_you_msg );
+		$content = apply_filters( 'wpec_thank_you_message', $content );
 
-		return $thank_you_msg;
+		return $content;
 	}
 
 	/**

--- a/wp-express-checkout/public/views/templates/content-thank-you-downloads.php
+++ b/wp-express-checkout/public/views/templates/content-thank-you-downloads.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Thank You page template
+ *
+ * @package wp-express-checkout
+ */
+?>
+<div class='wpec-thank-you-page-download-link'>
+	<span><?php echo _n( 'Download link', 'Download links', count( $downloads ), 'wp-express-checkout' ); ?>:</span>
+	<br/>
+	[wpec_ty_download_link]
+</div>

--- a/wp-express-checkout/public/views/templates/content-thank-you.php
+++ b/wp-express-checkout/public/views/templates/content-thank-you.php
@@ -1,39 +1,19 @@
 <?php
-
 /**
  * Thank You page template
  *
  * @package wp-express-checkout
  */
-
-// @todo: Replace following variables usage with appropriate merge tag and shortcode:
-$order_id  = (int) $_GET['order_id'];
-$downloads = WP_Express_Checkout\View_Downloads::get_order_downloads_list( $order_id );
 ?>
 
 <div class="wpec_thank_you_message">
 	<p><?php esc_html_e( 'Thank you for your purchase.', 'wp-express-checkout' ); ?></p>
 	<p><?php esc_html_e( 'Your purchase details are below:', 'wp-express-checkout' ); ?></p>
-	<p>{product_details}</p>
-	<p><?php esc_html_e( 'Transaction ID: ', 'wp-express-checkout' ); ?>{transaction_id}</p>
 
-	<?php
-	if ( ! empty( $downloads ) ) {
-	?>
-		<br />
-		<div class='wpec-thank-you-page-download-link'>
-			<span><?php echo _n( 'Download link', 'Download links', count( $downloads ), 'wp-express-checkout' ); ?>:</span>
-			<br/>
-			<?php
-			$download_txt      = __( 'Click here to download', 'wp-express-checkout' );
-			$link_tpl          = apply_filters( 'wpec_downloads_list_item_template', '%1$s - <a href="%2$s">%3$s</a><br/>' );
-			foreach ( $downloads as $name => $download_url ) {
-				printf( $link_tpl, $name, $download_url, $download_txt );
-			}
-			?>
-		</div>
-	<?php
-	}
-	?>
+	[wpec_ty_product_details]
+
+	<p><?php esc_html_e( 'Transaction ID: ', 'wp-express-checkout' ); ?>[wpec_ty_transaction_id]</p>
+
+	[wpec_ty_downloads]
 
 </div><!-- end .wpec_thank_you_message-->

--- a/wp-express-checkout/public/views/templates/content-thank-you.php
+++ b/wp-express-checkout/public/views/templates/content-thank-you.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Thank You page template
+ *
+ * @package wp-express-checkout
+ */
+
+// @todo: Replace following variables usage with appropriate merge tag and shortcode:
+$order_id  = (int) $_GET['order_id'];
+$downloads = WP_Express_Checkout\View_Downloads::get_order_downloads_list( $order_id );
+?>
+
+<div class="wpec_thank_you_message">
+	<p><?php esc_html_e( 'Thank you for your purchase.', 'wp-express-checkout' ); ?></p>
+	<p><?php esc_html_e( 'Your purchase details are below:', 'wp-express-checkout' ); ?></p>
+	<p>{product_details}</p>
+	<p><?php esc_html_e( 'Transaction ID: ', 'wp-express-checkout' ); ?>{transaction_id}</p>
+
+	<?php
+	if ( ! empty( $downloads ) ) {
+	?>
+		<br />
+		<div class='wpec-thank-you-page-download-link'>
+			<span><?php echo _n( 'Download link', 'Download links', count( $downloads ), 'wp-express-checkout' ); ?>:</span>
+			<br/>
+			<?php
+			$download_txt      = __( 'Click here to download', 'wp-express-checkout' );
+			$link_tpl          = apply_filters( 'wpec_downloads_list_item_template', '%1$s - <a href="%2$s">%3$s</a><br/>' );
+			foreach ( $downloads as $name => $download_url ) {
+				printf( $link_tpl, $name, $download_url, $download_txt );
+			}
+			?>
+		</div>
+	<?php
+	}
+	?>
+
+</div><!-- end .wpec_thank_you_message-->

--- a/wp-express-checkout/tests/public/includes/test-class-shortcodes.php
+++ b/wp-express-checkout/tests/public/includes/test-class-shortcodes.php
@@ -305,6 +305,158 @@ class ShortcodesTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers WP_Express_Checkout\Shortcodes::shortcode_wpec_thank_you_parts
+	 */
+	public function testShortcode_wpec_thank_you_parts__no_part() {
+		$output = $this->object->shortcode_wpec_thank_you_parts( [], '', 'wpec_ty' );
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * @covers WP_Express_Checkout\Shortcodes::shortcode_wpec_thank_you_parts
+	 */
+	public function testShortcode_wpec_thank_you_parts__reflects_by_shortcode() {
+		$output = $this->object->shortcode_wpec_thank_you_parts( [], '', 'wpec_ty_test' );
+		$this->assertEquals( '{test}', $output );
+	}
+
+	/**
+	 * @covers WP_Express_Checkout\Shortcodes::shortcode_wpec_thank_you_parts
+	 */
+	public function testShortcode_wpec_thank_you_parts__reflects_by_atts() {
+		$output = $this->object->shortcode_wpec_thank_you_parts( [ 'field' => 'test2' ], '', 'wpec_ty' );
+		$this->assertEquals( '{test2}', $output );
+	}
+
+	/**
+	 * @covers WP_Express_Checkout\Shortcodes::shortcode_wpec_thank_you_downloads
+	 */
+	public function testShortcode_wpec_thank_you_downloads__no_downloads() {
+		$product_id = $this->factory->post->create(
+			[
+				'post_type'  => Products::$products_slug,
+			]
+		);
+		$order = Orders::create();
+		$order->add_item( Products::$products_slug, $product_id, 0, 1, $product_id );
+
+		$_GET['order_id'] = $order->get_id();
+
+		$output = $this->object->shortcode_wpec_thank_you_downloads();
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * @covers WP_Express_Checkout\Shortcodes::shortcode_wpec_thank_you_downloads
+	 */
+	public function testShortcode_wpec_thank_you_downloads_reflects_template() {
+		$product_id = $this->factory->post->create(
+			[
+				'post_type'  => Products::$products_slug,
+				'meta_input' => [
+					'ppec_product_upload' => 'dummy'
+				]
+			]
+		);
+		$order = Orders::create();
+		$order->add_item( Products::$products_slug, $product_id, 0, 1, $product_id );
+
+		$_GET['order_id'] = $order->get_id();
+
+		$output = $this->object->shortcode_wpec_thank_you_downloads();
+		$this->assertContains( 'wpec-thank-you-page-download-link', $output );
+	}
+
+	/**
+	 * @covers WP_Express_Checkout\Shortcodes::shortcode_wpec_thank_you_downloads
+	 */
+	public function testShortcode_wpec_thank_you_downloads_reflects_content() {
+		$product_id = $this->factory->post->create(
+			[
+				'post_type'  => Products::$products_slug,
+				'meta_input' => [
+					'ppec_product_upload' => 'dummy'
+				]
+			]
+		);
+		$order = Orders::create();
+		$order->add_item( Products::$products_slug, $product_id, 0, 1, $product_id );
+
+		$_GET['order_id'] = $order->get_id();
+
+		$output = $this->object->shortcode_wpec_thank_you_downloads( [], '[wpec_ty_download_link anchor_text="test download link"]' );
+		$this->assertContains( 'test download link', $output );
+	}
+
+	/**
+	 * @covers WP_Express_Checkout\Shortcodes::shortcode_wpec_thank_you_download_link
+	 */
+	public function testShortcode_wpec_thank_you_download_link() {
+		$product_id = $this->factory->post->create(
+			[
+				'post_type'  => Products::$products_slug,
+			]
+		);
+		$order = Orders::create();
+		$order->add_item( Products::$products_slug, $product_id, 0, 1, $product_id );
+
+		$_GET['order_id'] = $order->get_id();
+
+		$output = $this->object->shortcode_wpec_thank_you_download_link();
+		$this->assertEmpty( $output );
+	}
+
+
+	/**
+	 * @covers WP_Express_Checkout\Shortcodes::shortcode_wpec_thank_you_download_link
+	 */
+	public function testShortcode_wpec_thank_you_download_link_reflects() {
+		$product_id = $this->factory->post->create(
+			[
+				'post_type'  => Products::$products_slug,
+				'meta_input' => [
+					'ppec_product_upload' => 'dummy'
+				]
+			]
+		);
+		$order = Orders::create();
+		$order->add_item( Products::$products_slug, $product_id, 0, 1, $product_id );
+
+		$_GET['order_id'] = $order->get_id();
+
+		$output = $this->object->shortcode_wpec_thank_you_download_link(
+			[
+				'anchor_text' => "test download link 2",
+				'target'      => "_test_blank",
+			]
+		);
+		$this->assertContains( 'test download link 2', $output );
+		$this->assertContains( '_test_blank', $output );
+	}
+
+	public function test_wpec_ty_aliases() {
+		$tags = [
+			'first_name',
+			'last_name',
+			'product_details',
+			'payer_email',
+			'transaction_id',
+			'purchase_amt',
+			'purchase_date',
+			'coupon_code',
+			'currency_code',
+			'address',
+			'order_id',
+		];
+
+		foreach ( $tags as $tag ) {
+			$output = do_shortcode( "[wpec_ty_{$tag}]" );
+			$this->assertEquals( "{{$tag}}", $output );
+		}
+	}
+
+
+	/**
 	 * @covers WP_Express_Checkout\Shortcodes::generate_product_details_tag
 	 */
 	public function testGenerate_product_details_tag() {


### PR DESCRIPTION

1. Use `$content` parameter in `[wpec_thank_you shortcode]` callback:
- Moved default shortcode content to `content-thank-you.php` template
- Use `$content` parameter if not empty, otherwise fallback to default template

2. Added Thank You parts shortcodes:
* `[wpec_ty]` - The general wrapper for merge tags, like {transaction_id} and other.
* Aliases:
  - `[wpec_ty_first_name]` === `[wpec_ty field=first_name]` === {first_name}
  - `[wpec_ty_last_name]` === `[wpec_ty field=last_name]` === {last_name}
  - `[wpec_ty_product_details]` === `[wpec_ty field=first_name]` === {first_name}
  - `[wpec_ty_payer_email]` === `[wpec_ty field=product_details]` === {product_details}
  - `[wpec_ty_transaction_id]` === `[wpec_ty field=transaction_id]` === {transaction_id}
  - `[wpec_ty_purchase_amt]` === `[wpec_ty field=purchase_amt]` === {purchase_amt}
  - `[wpec_ty_purchase_date]` === `[wpec_ty field=purchase_date]` === {purchase_date}
  - `[wpec_ty_currency_code]` === `[wpec_ty field=currency_code]` === {currency_code}
  - `[wpec_ty_coupon_code]` === `[wpec_ty field=coupon_code]` === {coupon_code}
  - `[wpec_ty_address]` === `[wpec_ty field=address]` === {address}
  - `[wpec_ty_order_id]` === `[wpec_ty field=order_id]` === {order_id}
* `[wpec_ty_downloads]` - a wrapper for Downloads section.
* `[wpec_ty_download_link]` - generates links, should be used in the content of `[wpec_ty_downloads]`.
* Added template 'content-thank-you-downloads.php' - as default content for `[wpec_ty_downloads]`
* Added tests for new code.

Usage example:
```
[wpec_thank_you]

    <h3>Thank you for your purchase!</h3>

    <p>Your purchase details are below:</p>

    [wpec_ty_product_details]

    <p>Transaction ID: [wpec_ty_transaction_id]</p>

    [wpec_ty_downloads]
        <h3>Downloads:</h3>
        
        <p>This will be not visible if there are not downloads</p>
        
        [wpec_ty_download_link anchor_text="Get it now!" target="_self"]
    [/wpec_ty_downloads]
[/wpec_thank_you]
```
