### PR TITLE
Regenerate Download Permissions - new order action

### DIFF
--- a/wp-express-checkout/includes/class-view-downloads.php
+++ b/wp-express-checkout/includes/class-view-downloads.php
@@ -272,6 +272,11 @@ class View_Downloads {
 		}
 
 		$counter = $order->get_data( 'downloads_counter' );
+
+		if ( empty( $counter[ $file_name ] ) ) {
+			$counter[ $file_name ] = 0;
+		}
+
 		$counter[ $file_name ]++;
 		$order->add_data( 'downloads_counter', $counter );
 


### PR DESCRIPTION
Added new action "Reset Download Permissions"
![image](https://user-images.githubusercontent.com/4242025/139009267-fbda54fc-ff0c-4ea4-84de-dfe4bdbaf068.png)

### Some notes:
1. Download counter resets just fine, no issues.
2. Download duration resetting to 0 permanently. So if originally it was set for 24 hours, after resetting it will never expire. Because duration depends on the order date. So we would have to refresh order date to current to reset duration, what we don't want.