### PR TITLE
New Search an Order feature!

### DIFF
--- a/wp-express-checkout/admin/includes/class-orders-list.php
+++ b/wp-express-checkout/admin/includes/class-orders-list.php
@@ -18,9 +18,6 @@ class Orders_List {
 		add_filter( 'manage_edit-' . Orders::PTYPE . '_sortable_columns', array( __CLASS__, 'order_manage_sortable_columns' ) );
 		add_action( 'manage_' . Orders::PTYPE . '_posts_custom_column', array( __CLASS__, 'order_add_column_data' ), 10, 2 );
 		add_filter( 'list_table_primary_column',  array( __CLASS__, 'primary_column' ), 10, 2 );
-		// handle columns sorting and searching
-		add_action( 'pre_get_posts', array( __CLASS__, 'manage_search_sort_queries' ) );
-		add_action( 'posts_results', array( __CLASS__, 'set_search_term' ), 10, 2 );
 	}
 
 	/**
@@ -143,59 +140,6 @@ class Orders_List {
 				break;
 		}
 
-	}
-
-	public static function set_search_term( $posts, $query ) {
-
-		if ( ! is_admin() || ( empty( $query->query['post_type'] ) || $query->query['post_type'] !== Orders::PTYPE ) ) {
-			return $posts;
-		}
-
-		if ( ! empty( self::$search_term ) ) {
-			$query->set( 's', self::$search_term );
-			self::$search_term = false;
-		}
-		return $posts;
-	}
-
-	public static function manage_search_sort_queries( $query ) {
-
-		if ( ! is_admin() || ( empty( $query->query['post_type'] ) || $query->query['post_type'] !== Orders::PTYPE ) ) {
-			return;
-		}
-
-		$search_term = $query->query_vars['s'];
-		if ( ! empty( $search_term ) ) {
-			$query->set( 's', '' );
-			self::$search_term = $search_term;
-			$custom_fields     = array(
-				'wpec_order_customer_email',
-				'wpec_order_resource_id',
-			);
-			$meta_query        = array( 'relation' => 'OR' );
-
-			foreach ( $custom_fields as $custom_field ) {
-				array_push(
-					$meta_query,
-					array(
-						'key'     => $custom_field,
-						'value'   => $search_term,
-						'compare' => 'LIKE',
-					)
-				);
-			}
-
-			$query->set( 'meta_query', $meta_query );
-		}
-
-		$orderby = $query->get( 'orderby' );
-		switch ( $orderby ) {
-			case 'customer':
-				$query->set( 'meta_key', 'wpec_order_customer_email' );
-				$query->set( 'orderby', 'meta_value' );
-				break;
-			// to be continue...
-		}
 	}
 
 	/**

--- a/wp-express-checkout/includes/class-order.php
+++ b/wp-express-checkout/includes/class-order.php
@@ -529,6 +529,27 @@ class Order {
 	}
 
 	/**
+	 * Adds all order data tags to the order content field for using in search.
+	 */
+	public function generate_search_index() {
+		$renderer = new Order_Tags_Plain( $this );
+		$tags     = array_keys( Utils::get_dynamic_tags_white_list() );
+
+		foreach ( $tags as $tag ) {
+			$args[ $tag ] = $renderer->$tag();
+		}
+
+		$template = "{first_name} {last_name}\n";
+
+		$post_content = Utils::apply_dynamic_tags( $template, $args );
+		foreach ( $tags as $tag ) {
+			$post_content .= $tag . ':' . $renderer->$tag() . "\n";
+		}
+
+		$this->update_post( array( 'post_content' => $post_content ) );
+	}
+
+	/**
 	 * Updates the order's post data
 	 * @param $args array Array of values to update. See wp_update_post.
 	 */

--- a/wp-express-checkout/includes/class-payment-processor.php
+++ b/wp-express-checkout/includes/class-payment-processor.php
@@ -150,6 +150,8 @@ class Payment_Processor {
 
 		$order_id  = $order->get_id();
 
+		$order->generate_search_index();
+
 		// Send email to buyer if enabled.
 		Emails::send_buyer_email( $order );
 


### PR DESCRIPTION
As you can see, this feature adds less code than removes. Isn't this enough to say it's cool? Not? Ok, let me explain more.

Now we save all merge tags in the order content field, what enables the power of WordPress post search:
1. You can search by name, email, currency and other stuff without any search query hacking.
2. You can search using field name. For example search by order id "983" will return the order with id 983 and some other orders with 983 in transaction id.
![image](https://user-images.githubusercontent.com/4242025/139021465-b6498730-7843-45c3-a7c7-7bac983ef40f.png)
But you can search with field name "order_id:983" and get exact result
![image](https://user-images.githubusercontent.com/4242025/139021664-e3a55ff4-0101-4d5c-9e7d-673f8f14da0b.png)
3. Remember the WordPress exclude keyword feature? Add a minus before keyword: search by "USD" will return all order in USD currency, but search by "-USD" will return all orders with another currency.

See a sample of the data saved in the order content:

```
Artem Frolov
first_name:Artem
last_name:Frolov
payer_email:afrolov@appthemes.com
address:
product_details:Product Name: Some product
Quantity: 1
Price: $11.00
Color - Red: $1.00
Size - S: $0.00
Many more - Var 1: $0.00
Tax: $0.24
Shipping: $0.98
--------------------------------
Total: $13.22

Some product - download link: http://wp.home/wp-express-checkout/?wpec_download_file=37&order_id=983&key=5c3cfa96d9339a555a3c
Color - Red - download link: http://wp.home/wp-express-checkout/?wpec_download_file=37&order_id=983&key=f77b298cad14a0f3012f&grp_id=0&var_id=0

transaction_id:01H12831FX692230V
order_id:983
purchase_amt:13.22
purchase_date:October 27, 2021, 12:25 pm
coupon_code:0
currency_code:USD
custom_fields:Dropdown: Some item
Text field: n/a

custom_field_value_0:No
custom_field_value_1:n/a
custom_field_value_3:Some item
custom_field_value_2:n/a
custom_field_value_4:n/a
```